### PR TITLE
Run gitwatch in Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine:3.1
+RUN apk add --update bash git inotify-tools openssh && rm -rf /var/cache/apk/*
+
+RUN mkdir -p /app
+WORKDIR /app
+ADD gitwatch.sh ./ 
+
+RUN chmod 755 *.sh
+
+ENTRYPOINT ["./gitwatch.sh"]


### PR DESCRIPTION
Run example with ssh keys from host: `docker run -d --restart
unless-stopped --name gitwatch -v /root/.ssh/:/root/.ssh/ -v
/opt/repo_to_sync/:/repo -v /root/.gitconfig:/root/.gitconfig
salanki:gitwatch -r origin /repo`
