### PR TITLE
is_command should use hash instead of which

### DIFF
--- a/gitwatch.sh
+++ b/gitwatch.sh
@@ -120,7 +120,7 @@ cleanup () {
 
 # Tests for the availability of a command
 is_command () {
-	which "$1" &>/dev/null
+	hash "$1" 2>/dev/null
 }
 
 ###############################################################################


### PR DESCRIPTION
https://stackoverflow.com/questions/592620/how-to-check-if-a-program-exists-from-a-bash-script