### PR TITLE
macOS: try greadlink -f, then readlink -f, then readlink and warn about it

### DIFF
--- a/gitwatch.sh
+++ b/gitwatch.sh
@@ -185,7 +185,15 @@ trap "cleanup" EXIT # make sure the timeout is killed when exiting script
 if [ "$(uname)" != "Darwin" ]; then
     IN=$(readlink -f "$1")
 else
-    IN=$(greadlink -f "$1")
+    if is_command "greadlink"; then
+      IN=$(greadlink -f "$1")
+    else
+      IN=$(readlink -f "$1")
+      if [ $? -eq 1 ]; then
+        echo "Seems like your readlink doesn't support '-f'. Running without. Please 'brew install coreutils'."
+        IN=$(readlink "$1")
+      fi
+    fi;
 fi;
 
 


### PR DESCRIPTION
I had coreutils installed via brew, but no g-prefixed versions, so
running greadlink failed.

First try `greadlink -f`.
If `greadlink` does not exist, try `readlink -f`.
If it fails because macOS' version has no `-f` option, run it without and ask to `brew install coreutils`.