### PR TITLE
Update README and systemd script

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Notes:
 * currently, folders are always watched recursively
 
 ## Usage
-`gitwatch.sh <file or directory to watch> [-r <remote> [-b <branch>]]`<br />
+`gitwatch.sh [-r <remote> [-b <branch>]] <file or directory to watch>`<br />
 It is expected that the watched file/directory are already in a git repository (the script will not create a repository). If a folder is being watched, this will be watched fully recursively; this also means that all files and sub-folders added and removed from the directory will always be added and removed in the next commit. The `.git` folder will be excluded from the `inotifywait` call so changes to it will not cause unnecessary triggering of the script.
 
 ### Starting on Boot

--- a/gitwatch@.service
+++ b/gitwatch@.service
@@ -3,7 +3,7 @@ Description=Watch file or directory and git commit all changes. run with: system
 
 [Service]
 Environment="SCRIPT_ARGS=%I"
-ExecStart=/usr/bin/gitwatch $SCRIPT_ARGS
+ExecStart=/usr/local/bin/gitwatch $SCRIPT_ARGS
 ExecStop=/bin/true
 
 [Install]


### PR DESCRIPTION
I updated the usage section of the readme to put the file/folder path at the end which is how the --help flag describes how to use the script.

Also, I updated the systemd service to point to /usr/local/bin since that's where the README suggests to install it and where bpkg installs it.