### PR TITLE
Fixed the broken -e command line option

### DIFF
--- a/gitwatch.sh
+++ b/gitwatch.sh
@@ -38,7 +38,6 @@
 REMOTE=""
 BRANCH=""
 SLEEP_TIME=2
-EVENTS="close_write,move,delete,create"
 DATE_FMT="+%Y-%m-%d %H:%M:%S"
 COMMITMSG="Scripted auto-commit on change (%d) by gitwatch.sh"
 LISTCHANGES=-1
@@ -157,13 +156,14 @@ if [ -z "$GW_INW_BIN" ]; then
     # if Mac, use fswatch
     if [ "$(uname)" != "Darwin" ]; then
         INW="inotifywait";
+        EVENTS="${EVENTS:-close_write,move,delete,create}"
     else
         INW="fswatch";
         # default events specified via a mask, see
         # https://emcrisostomo.github.io/fswatch/doc/1.14.0/fswatch.html/Invoking-fswatch.html#Numeric-Event-Flags
         # default of 414 = MovedTo + MovedFrom + Renamed + Removed + Updated + Created
         #                = 256 + 128+ 16 + 8 + 4 + 2
-        EVENTS="--event=414"
+        EVENTS="${EVENTS:---event=414}"
     fi;
 else
     INW="$GW_INW_BIN";

--- a/gitwatch.sh
+++ b/gitwatch.sh
@@ -38,6 +38,7 @@
 REMOTE=""
 BRANCH=""
 SLEEP_TIME=2
+EVENTS="close_write,move,delete,create"
 DATE_FMT="+%Y-%m-%d %H:%M:%S"
 COMMITMSG="Scripted auto-commit on change (%d) by gitwatch.sh"
 LISTCHANGES=-1
@@ -156,7 +157,6 @@ if [ -z "$GW_INW_BIN" ]; then
     # if Mac, use fswatch
     if [ "$(uname)" != "Darwin" ]; then
         INW="inotifywait";
-        EVENTS="close_write,move,delete,create";
     else
         INW="fswatch";
         # default events specified via a mask, see


### PR DESCRIPTION
Instead of moving the defaults to the top of the file, I used the VAR="${VAR:-defaults} structure.
https://unix.stackexchange.com/questions/122845/using-a-b-for-variable-assignment-in-scripts/122878