### PR TITLE
Update inotifywait parameters to also watch move_self and modify

### DIFF
--- a/gitwatch.sh
+++ b/gitwatch.sh
@@ -156,7 +156,7 @@ if [ -z "$GW_INW_BIN" ]; then
     # if Mac, use fswatch
     if [ "$(uname)" != "Darwin" ]; then
         INW="inotifywait";
-        EVENTS="${EVENTS:-close_write,move,move_self,delete,create}"
+        EVENTS="${EVENTS:-close_write,move,move_self,delete,create,modify}"
     else
         INW="fswatch";
         # default events specified via a mask, see

--- a/gitwatch.sh
+++ b/gitwatch.sh
@@ -156,7 +156,7 @@ if [ -z "$GW_INW_BIN" ]; then
     # if Mac, use fswatch
     if [ "$(uname)" != "Darwin" ]; then
         INW="inotifywait";
-        EVENTS="${EVENTS:-close_write,move,delete,create}"
+        EVENTS="${EVENTS:-close_write,move,move_self,delete,create}"
     else
         INW="fswatch";
         # default events specified via a mask, see


### PR DESCRIPTION
Update the parameters to `inotifywait` to also watch `move_self`, as vim uses it on linux (at least on Ubuntu 18.04).

According to https://github.com/guard/guard/wiki/Analysis-of-inotify-events-for-different-editors, vim using `move_self` is expected behavior, and nano uses `modify`.

Also referencing #13, since this was discussed before.