### PR TITLE
Ensure no color-format output

### DIFF
--- a/gitwatch.sh
+++ b/gitwatch.sh
@@ -237,7 +237,7 @@ if [ -n "$GIT_DIR" ]; then
         exit 1;
     fi
 
-    GIT="$GIT --work-tree $TARGETDIR --git-dir $GIT_DIR"
+    GIT="$GIT --no-pager --work-tree $TARGETDIR --git-dir $GIT_DIR"
 fi
 
 # Check if commit message needs any formatting (date splicing)


### PR DESCRIPTION
Even after using the `-L` switch (rather than `-l`) the git commit is still having color code in it (something like `29: �[1;31m-1. [Install..`.)

I think it's because I am using a custom pager which produces color code. Since `gitwatch` is non-interactive use, the no pager flag ensure no custom pager will be used.
After adding the flag on my local machine the commit message display as expected, without color code in it.