### PR TITLE
double-double-quote target directory to support pathes with spaces

### DIFF
--- a/gitwatch.sh
+++ b/gitwatch.sh
@@ -203,10 +203,10 @@ if [ -d "$1" ]; then # if the target is a directory
     TARGETDIR=$(sed -e "s/\/*$//" <<<"$IN") # dir to CD into before using git commands: trim trailing slash, if any
     # construct inotifywait-commandline
     if [ "$(uname)" != "Darwin" ]; then
-        INW_ARGS=("-qmr" "-e" "$EVENTS" "--exclude" "'(\.git/|\.git$)'" "$TARGETDIR")
+        INW_ARGS=("-qmr" "-e" "$EVENTS" "--exclude" "'(\.git/|\.git$)'" "\"$TARGETDIR\"")
     else
         # still need to fix EVENTS since it wants them listed one-by-one
-        INW_ARGS=("--recursive" "$EVENTS" "--exclude" "'(\.git/|\.git$)'" "$TARGETDIR")
+        INW_ARGS=("--recursive" "$EVENTS" "--exclude" "'(\.git/|\.git$)'" "\"$TARGETDIR\"")
     fi;
     GIT_ADD_ARGS="--all ." # add "." (CWD) recursively to index
     GIT_COMMIT_ARGS="" # add -a switch to "commit" call just to be sure


### PR DESCRIPTION
Awesome project.  
I tried to watch a directory whose parent directory has a space in it's name and the eval call stripped these away. Adding another pair of escaped doublequotes to the variable solved that.  
(It's also still working with dirs without spaces.)