### PR TITLE
Bug fix: allow spaces in target directory

### DIFF
--- a/gitwatch.sh
+++ b/gitwatch.sh
@@ -325,7 +325,7 @@ diff-lines() {
 #   process some time (in case there are a lot of changes or w/e); if there is already a timer
 #   running when we receive an event, we kill it and start a new one; thus we only commit if there
 #   have been no changes reported during a whole timeout period
-eval "$INW" "${INW_ARGS[@]}" | while read -r line; do
+eval "$INW" "${INW_ARGS[@]@Q}" | while read -r line; do
   # is there already a timeout process running?
   if [[ -n $SLEEP_PID ]] && kill -0 "$SLEEP_PID" &> /dev/null; then
     # kill it and wait for completion


### PR DESCRIPTION
The `@Q` format directive in Bash escapes characters such as space so that they can be correctly interpreted by eval.

Read more: https://stackoverflow.com/a/27817504/401059

Fixes https://github.com/gitwatch/gitwatch/issues/109

I only tested the fix locally on my computer.