### PR TITLE
Update nix flake to read `gitwatch.nix` instead of `gitwatch.sh`

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,12 +93,11 @@ for Archlinux. Install it with you favorite aur helper.
 
 #### As Module
 
-Say you add this as input `gitwatch` to your flake. Then you may want to append
-field `gitwatch.modules` to your `nixosSystem` modules. Then you are able to
-enable `services.gitwatch.*` service in per-repository mode. Like next:
+If you add `gitwatch` to your flake, and append field `gitwatch.modules` to
+your `nixosSystem` modules, then you can enable `services.gitwatch.*`:
 
 ```nix
-services.gitwatch.my-repo = {
+services.gitwatch.<service name> = {
     enable = true;
     path = "/home/me/my-repo";
     remote = "git@github.com:me/my-repo.git";
@@ -106,7 +105,9 @@ services.gitwatch.my-repo = {
 };
 ```
 
-This will make NixOS to create `systemd` service for `my-repo` repository.
+This will make NixOS to create `systemd` service named `gitwatch-<service name>`.
+Note that the service does not start before reboot, or alternatively if it is
+started manually: `systemctl start gitwatch-<service name>`.
 
 #### As Package
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,58 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1712449641,
+        "narHash": "sha256-U9DDWMexN6o5Td2DznEgguh8TRIUnIl9levmit43GcI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "600b15aea1b36eeb43833a50b0e96579147099ff",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
         in
         {
           packages = rec {
-            gitwatch = pkgs.callPackage ./gitwatch.sh { };
+            gitwatch = pkgs.callPackage ./gitwatch.nix { };
             default = gitwatch;
           };
         });


### PR DESCRIPTION
After testing out the Nix module, i got the same error as described in #119 . Inspecting the `flake.nix`, I saw that the wrong file was referenced. I also agree with the comment that a `flake.lock` file should be included. I have added some text to the README as well.

Closes #119
