### PR TITLE
fix sending all script arguments as arg 1

### DIFF
--- a/gitwatch@.service
+++ b/gitwatch@.service
@@ -3,7 +3,7 @@ Description=Watch file or directory and git commit all changes. run with: system
 
 [Service]
 Environment="SCRIPT_ARGS=%I"
-ExecStart=/usr/local/bin/gitwatch ${SCRIPT_ARGS}
+ExecStart=/usr/bin/bash -c "/usr/local/bin/gitwatch ${SCRIPT_ARGS}"
 ExecStop=/bin/true
 
 [Install]


### PR DESCRIPTION
Previously the string containing all arguments was passed as $1, resulting in this problem:

```
Apr 11 16:10:01 fedora gitwatch.sh[62982]: using target:
Apr 11 16:10:01 fedora gitwatch.sh[62982]: '-r git@..../notes' /home/kieran/work/notes/
Apr 11 16:10:01 fedora gitwatch.sh[62982]: Error: The target is neither a regular file nor a directory.
```

Running gitwatch through bash separates the arguments and fixes this.