### PR TITLE
[nix] Add `wantedBy` to systemd service

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -19,6 +19,7 @@ let
       {
         inherit (cfg) enable;
         after = [ "network-online.target" ];
+        wantedBy = [ "multi-user.target" ];
         description = "gitwatch for ${name}";
         path = with pkgs; [ gitwatch git openssh ];
         script = ''


### PR DESCRIPTION
This field needed to properly enable service by configuration.