### PR TITLE
Add pre-commit setup

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,68 @@
+---
+name: pre-commit
+on:
+  pull_request:
+  push:
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    env:
+      LOG_TO_CS: ./logToCs.py
+      RAW_LOG: pre-commit.log
+      CS_XML: pre-commit.xml
+      SKIP: no-commit-to-branch
+    steps:
+      - run: sudo apt-get update && sudo apt-get install cppcheck
+        if: false
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        if: false
+        with:
+          cache: pip
+          python-version: 3.12.1
+      - run: python -m pip install pre-commit regex
+      - uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/pre-commit/
+          key:
+            pre-commit-4|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml')
+            }}
+      - name: Run pre-commit hooks
+        run: |
+          set -o pipefail
+          pre-commit gc
+          pre-commit run --show-diff-on-failure --color=always --all-files | tee ${RAW_LOG}
+      - name: Convert Raw Log to CheckStyle format (launch script)
+        # if: ${{ failure() }}
+        if: false
+        run: |
+          python ${LOG_TO_CS} ${RAW_LOG} ${CS_XML}
+      - name: Convert Raw Log to Checkstyle format (launch action)
+        uses: mdeweerd/logToCheckStyle@v2025.1.1
+        if: ${{ failure() }}
+        with:
+          in: ${{ env.RAW_LOG }}
+          out: ${{ env.CS_XML }}
+      - name: Annotate Source Code with Messages
+        uses: staabm/annotate-pull-request-from-checkstyle-action@v1
+        if: ${{ failure() }}
+        with:
+          files: ${{ env.CS_XML }}
+          notices-as-warnings: true # optional
+          prepend-filename: true # optional
+      - uses: actions/cache/save@v4
+        if: ${{ ! cancelled() }}
+        with:
+          path: ~/.cache/pre-commit/
+          key:
+            pre-commit-4|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml')
+            }}
+      - name: Provide log as artifact
+        uses: actions/upload-artifact@v4
+        if: ${{ ! cancelled() }}
+        with:
+          name: precommit-logs
+          path: |
+            ${{ env.RAW_LOG }}
+            ${{ env.CS_XML }}
+          retention-days: 2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,87 @@
+---
+files: ^(.*\.(py|json|md|sh|yaml|yml|cfg|txt))$
+exclude: ^(\.[^/]*cache/.*|demo/.*|debug/.*)$
+repos:
+  # Disable because this does not work for the main author.
+  # - repo: https://github.com/pre-commit/mirrors-prettier
+  #   rev: "v2.7.1"
+  #   stages: [manual]
+  #   hooks:
+  #     - id: prettier
+  - repo: https://github.com/executablebooks/mdformat
+    # Do this before other tools "fixing" the line endings
+    rev: 0.7.22
+    hooks:
+      - id: mdformat
+        name: Format Markdown
+        entry: mdformat # Executable to run, with fixed options
+        language: python
+        types: [markdown]
+        args: [--wrap, "75", --number]
+        # files: ^HomeAssistant.md$
+        additional_dependencies:
+          - mdformat-toc
+          - mdformat-beautysh
+          - mdformat-config
+          - mdformat-gfm
+          - setuptools
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: no-commit-to-branch
+        args: [--branch, main]
+      - id: check-yaml
+        # Exclude because of bug in checker
+        exclude: ^(docker-compose\.yml|.*/release-drafter\.yml)$
+      - id: debug-statements
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-json
+      - id: mixed-line-ending
+      - id: check-builtin-literals
+      - id: check-ast
+      - id: check-merge-conflict
+      - id: check-executables-have-shebangs
+      - id: check-shebang-scripts-are-executable
+      - id: check-docstring-first
+      - id: fix-byte-order-marker
+      - id: check-case-conflict
+      - id: pretty-format-json
+        exclude: ^(.vscode|.devcontainer)
+        args:
+          # order of keys in manifest.json is "special"
+          - --no-sort-keys
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v4.0.0-alpha.8
+    hooks:
+      - id: prettier
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.35.1
+    hooks:
+      - id: yamllint
+        args:
+          - --no-warnings
+          - -d
+          - "{extends: relaxed, rules: {line-length: {max: 90}}}"
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell
+        # exclude: (\.md|apps.yaml|translations/.*.yaml)$
+  - repo: https://github.com/IamTheFij/docker-pre-commit
+    rev: v3.0.1
+    hooks:
+      - id: docker-compose-check
+  - repo: https://github.com/lovesegfault/beautysh.git
+    rev: v6.2.1
+    hooks:
+      - id: beautysh
+        args: [ "-i", "2" ]
+        additional_dependencies:
+          - setuptools
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+        files: ^[^\.].*\.sh$
+        args: [--shell, bash]


### PR DESCRIPTION
This adds a pre-commit setup which in turn wil run the tools configured in its configuration file when it is executed.
(On git commit, in ci).

This includes a github workflow that runs pre-commit.

I only added the flow - no "fixes" - you may dislike some or all suggestions.

shelcheck hase some false positives, but notices an interesting point of attention  for `eval "$INW" "${INW_ARGS[@]}"`.